### PR TITLE
refactor: clean upload endpoint response, delegate command assembly to client

### DIFF
--- a/src/routes/uploadRoutes.js
+++ b/src/routes/uploadRoutes.js
@@ -242,20 +242,9 @@ router.get('/bridge-tokens', async (req, res) => {
                 'Authorization': headers['Authorization'].substring(0, 100) + '...'
             });
             
-            // Generate and log curl command
-            const curlCommand = `curl -X POST \\
-  -H "X-Auth-Secret: ${headers['X-Auth-Secret']}" \\
-  -H "Authorization: ${headers['Authorization']}" \\
-  -F "file=@/path/to/your/file.txt" \\
-  https://up.storacha.network/bridge`;
-            
-            logger.info('[bridge-tokens] 🧪 Test with curl:');
-            logger.info('[bridge-tokens] ' + curlCommand);
-            
+            // Client is responsible for constructing the upload request (e.g., via curl) using these headers.
             res.json({ 
-                headers,
-                curlCommand,
-                note: 'Replace /path/to/your/file.txt with actual file path for testing'
+                headers
             });
             
         } catch (err) {


### PR DESCRIPTION
### Summary
Simplifies the API response from the upload endpoint.

### Changes
- Removed embedded `curlCommand` from the response
- Response now only includes headers and metadata necessary for authenticated upload
- Client is responsible for constructing request (e.g. via curl)

### Rationale
- Reduces server-side complexity
- Promotes separation of concerns
- Makes the response easier to integrate across various clients

### Verification
- [x] Confirmed only `uploadRoutes.js` is modified
- [x] Verified the command string is no longer returned
- [x] Manually tested that response still contains required headers for upload