### PR TITLE
Refactor auth flow to use login instead of deprecated authorize

### DIFF
--- a/src/lib/adminClientManager.js
+++ b/src/lib/adminClientManager.js
@@ -40,9 +40,9 @@ export async function createAndAuthorizeNewClient(email) {
     const store = new StoreMemory();
     const client = await createClient({ principal, store });
 
-    logger.info('Starting interactive authorization flow', { email });
-    await client.authorize(email);
-    logger.info('Interactive authorization successful', { email });
+    logger.info('Starting interactive login flow', { email });
+    await client.login(email);
+    logger.info('Interactive login successful', { email });
 
     const archive = principal.toArchive();
     const serializableArchive = {


### PR DESCRIPTION
Closes #44 

The issue was that client.authorize() is now deprecated. It wasn't properly authenticating the client with the Storacha service, which meant space.name couldn't retrieve the actual names. By switching to client.login(), we get proper authentication and the space names work as expected.