### PR TITLE
Add account plan info to account-usage

### DIFF
--- a/API.md
+++ b/API.md
@@ -357,7 +357,7 @@ Get total storage usage across all spaces for the authenticated admin.
 
 **Required header:** `x-session-id` (admin session ID)
 
-**Description:** Returns the total storage usage for all spaces owned by the admin, as well as per-space usage breakdown.
+**Description:** Returns the total storage usage for all spaces owned by the admin, as well as per-space usage breakdown and the admin's plan product identifier.
 
 **Request:**
 ```bash
@@ -383,7 +383,8 @@ curl -H "x-session-id: your-session-id" \
         "human": "0.0112 MB"
       }
     }
-  ]
+  ],
+  "planProduct": "did:web:starter.web3.storage"
 }
 ```
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -114,11 +114,13 @@ CREATE TABLE IF NOT EXISTS admin_agents (
     agentData TEXT NOT NULL,
     createdAt INTEGER NOT NULL,
     updatedAt INTEGER NOT NULL,
-    status TEXT CHECK(status IN ('pending', 'active', 'failed')) NOT NULL DEFAULT 'pending'
+    status TEXT CHECK(status IN ('pending', 'active', 'failed')) NOT NULL DEFAULT 'pending',
+    planProduct TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_admin_agents_email ON admin_agents(adminEmail);
 CREATE INDEX IF NOT EXISTS idx_admin_agents_status ON admin_agents (status);
+CREATE INDEX IF NOT EXISTS idx_admin_agents_planProduct ON admin_agents(planProduct);
 
 
 -- =============================================================================


### PR DESCRIPTION
- adds plan product information to the response for better account management.

responses format change:
```
{
  "totalUsage": { ... },
  "spaces": [ ... ],
+ "planProduct": "..."
}
```