### PR TITLE
fix issue where delegation grew with number of spaces

### DIFF
--- a/src/lib/adminClientManager.js
+++ b/src/lib/adminClientManager.js
@@ -13,7 +13,7 @@ const clientCache = new Map();
  * @param {string} principalKey - The private key string for the agent.
  * @returns {Promise<import('@web-storage/w3up-client').Client>}
  */
-async function getClientForPrincipal(principalKey) {
+export async function getClientForPrincipal(principalKey) {
     const archive = JSON.parse(principalKey);
     const restoredArchive = {
         id: archive.id,

--- a/src/lib/token-generation.js
+++ b/src/lib/token-generation.js
@@ -108,10 +108,10 @@ export async function generateTokens(adminEmailOrUserDid, resource, options = {}
         if (!adminAgent || adminAgent.status !== 'active') {
             throw new Error(`No active admin agent found for ${adminEmail}`);
         }
-        
-        // Create the admin's client (which has delegations loaded from login)
-        const { getAdminClient } = await import('./adminClientManager.js');
-        client = await getAdminClient(adminEmail, adminAgent.agentData);
+
+        // Get the admin's client with their loaded delegations from login
+        const { getClientForPrincipal } = await import('./adminClientManager.js');
+        client = await getClientForPrincipal(adminAgent.agentData);
         
         // Ensure we have the latest delegations
         try {

--- a/src/routes/delegationRoutes.js
+++ b/src/routes/delegationRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { ensureAuthenticated } from './authRoutes.js';
 import { logger } from '../lib/logger.js';
-import { getClient, getAdminClient } from '../lib/w3upClient.js';
+import { getAdminClient } from '../lib/adminClientManager.js';
 import { CarWriter } from '@ipld/car';
 import { base64 } from "multiformats/bases/base64";
 import { parse as parseDID } from '@ipld/dag-ucan/did';


### PR DESCRIPTION
- fix 431 headers too large for delegated users with more than 4 spaces
- delegation always only includes admin's proof for the specific space + user's delegation for that space 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Export getClientForPrincipal and update token generation and delegation routes to use adminClientManager-based clients built from stored principals.
> 
> - **Backend**:
>   - **Admin Client Management**:
>     - Export `getClientForPrincipal` in `src/lib/adminClientManager.js` for principal-based client creation.
>   - **Token Generation**:
>     - Replace usage of `getAdminClient` with `getClientForPrincipal` in `src/lib/token-generation.js` to build the admin client from stored `agentData`.
>   - **Delegation Routes**:
>     - Switch imports to `getAdminClient` from `src/lib/adminClientManager.js` in `src/routes/delegationRoutes.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cebd87843181a72627bad1724d4c537bf8958ec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->