### PR TITLE
Fix multi device admin auth

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -52,14 +52,18 @@ CREATE INDEX IF NOT EXISTS idx_delegations_createdBy_spaceDid ON delegations(cre
 -- =============================================================================
 -- Table: did_email_mapping
 -- Maps user DIDs to their email addresses for identification.
+-- Supports multiple DIDs per email (multiple devices per admin).
 -- =============================================================================
 CREATE TABLE IF NOT EXISTS did_email_mapping (
-    did TEXT PRIMARY KEY,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    did TEXT NOT NULL,
     email TEXT NOT NULL,
-    createdAt INTEGER NOT NULL
+    createdAt INTEGER NOT NULL,
+    UNIQUE(email, did)
 );
 
 CREATE INDEX IF NOT EXISTS idx_did_email_mapping_email ON did_email_mapping(email);
+CREATE INDEX IF NOT EXISTS idx_did_email_mapping_did ON did_email_mapping(did);
 
 
 -- =============================================================================


### PR DESCRIPTION
## enable multi-device admin authentication

- allows admins to authenticate from multiple devices with different DIDs. 
- each device requires email + DID verification + DID verification

**changes:**
- updated `did_email_mapping` schema to support multiple DIDs per email
- added `handleNewDeviceLogin()` for new device authentication flow
- modified `handleAdminLogin()` to route based on DID registration status
